### PR TITLE
[BUGFIX] Fix typo3-ter/* package replacement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
 	},
 	"replace": {
 		"extension_builder": "self.version",
-		"typo3-ter/extension_builder": "self.version"
+		"typo3-ter/extension-builder": "self.version"
 	},
 	"config": {
 		"vendor-dir": ".Build/vendor",


### PR DESCRIPTION
The name of the package on composer.typo3.org is typo3-ter/extension-builder.
